### PR TITLE
Make Replayer robust for basic recording workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,29 +21,34 @@ Explore our Showcases at [rebrowse.me](https://rebrowse.me)
 - Scenario: Book an Airbnb apartment with specific conditions
 - Environment: Chrome browser with a personal Google account
 
+
 [![Airbnb Booking Demo](https://img.youtube.com/vi/1kQu8oYG-2g/0.jpg)](https://youtu.be/1kQu8oYG-2g)
 
-*Click the thumbnail to watch [on YouTube](https://youtu.be/1kQu8oYG-2g)!*
+(Recording demo is coming soon....!!!)
 
 Follow [me on Twitter](https://x.com/n0rizkitty) for the latest updates!
 
-## Roadmap
+---
+# Web App
 
-We are going to build a marketplace, where users can share cross-app workflows by recording, instead of node editors like Zapier or n8n.      
-Check out our [Roadmap](./doc/ROADMAP.md).   
+<div style="display: flex; flex-direction: column; align-items: flex-start;">
+  <span style="font-size: 1.2em;"><strong>► Run Agent with text prompt</strong></span>
+  <ul>
+    <li>👍 Robust. </li>
+    <li>👎 needs long descriptive prompt. slow.</li>
+  </ul>
+  <img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-agent-tab.png" alt="Rebrowse Agent Tab" width="100%" style="display: block; margin-bottom: 10px;"/>
 
-<img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-flywheel.png" alt="Rebrowse Flywheel" width="350" style="display: block; margin-left: 0;">
+  <span style="font-size: 1.2em;"><strong>► Run Agent with recording</strong></span>
+  <ul>
+    <li>👍 Determinictic. 10x fast. 3x Accurate.</li>
+    <li>⚠️ AI-powered fall-back is WIP.</li>
+  </ul>
+  <img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-replay-tab.png" alt="Rebrowse Replay Tab" width="100%" style="display: block;"/>
+</div>
 
 ---
 ## Installation Guide
-
-<div style="display: flex; flex-direction: column; align-items: center;">
-  ► Run Agent with text prompt
-  <img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-agent-tab.png" alt="Rebrowse Agent Tab" width="100%" style="display: block; margin-bottom: 10px;"/>
-  ► Run Agent with recording
-
-  <img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-replay-tab.png" alt="Rebrowse Replay Tab" width="100%" style="display: block;"/>
-</div>
 
 ### Prerequisites
 - Python 3.8 or higher
@@ -188,6 +193,13 @@ Let me share our technical roadmap.
 I found that @browser-use team released [workflow-use](https://github.com/browser-use/workflow-use).
 I'm still researching their approach and objectives.   
 Let's talk more on [X](https://x.com/n0rizkitty) or [Telegram](https://x.com/n0rizkitty).
+
+## Product Roadmap
+
+We are going to build a marketplace, where users can share cross-app workflows by recording, instead of node editors like Zapier or n8n.      
+Check out our [Roadmap](./doc/ROADMAP.md).   
+
+<img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-flywheel.png" alt="Rebrowse Flywheel" width="350" style="display: block; margin-left: 0;">
 
 
 ### Gradio Development Mode

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Explore our Showcases at [rebrowse.me](https://rebrowse.me)
 Follow [me on Twitter](https://x.com/n0rizkitty) for the latest updates!
 
 ---
-# Web App
+## Two Agent Modes
 
 <div style="display: flex; flex-direction: column; align-items: flex-start;">
-  <span style="font-size: 1.2em;"><strong>► Run Agent with text prompt</strong></span>
+  <span style="font-size: 1.2em;"><strong>✍🏻 Text prompt</strong></span>
   <ul>
     <li>👍 Robust. </li>
     <li>👎 needs long descriptive prompt. slow.</li>
   </ul>
   <img src="https://raw.githubusercontent.com/zk1tty/rebrowse-app/main/assets/rebrowse-agent-tab.png" alt="Rebrowse Agent Tab" width="100%" style="display: block; margin-bottom: 10px;"/>
 
-  <span style="font-size: 1.2em;"><strong>► Run Agent with recording</strong></span>
+  <span style="font-size: 1.2em;"><strong>▶️ Recording</strong></span>
   <ul>
     <li>👍 Determinictic. 10x fast. 3x Accurate.</li>
     <li>⚠️ AI-powered fall-back is WIP.</li>

--- a/debug/manual_record_input_sample.jsonl
+++ b/debug/manual_record_input_sample.jsonl
@@ -1,0 +1,50 @@
+{"url": "chrome://new-tab-page/", "x": 364, "y": 287, "button": "left", "selector": "ntp-app", "text": null, "type": "mouse_click", "mods": [], "t": 0}
+{"url": "chrome://new-tab-page/", "key": "x", "code": "KeyX", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 691}
+{"url": "chrome://new-tab-page/", "key": ".", "code": "Period", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 314}
+{"url": "chrome://new-tab-page/", "key": "c", "code": "KeyC", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 236}
+{"url": "chrome://new-tab-page/", "key": "o", "code": "KeyO", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 334}
+{"url": "chrome://new-tab-page/", "key": "m", "code": "KeyM", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 34}
+{"url": "chrome://new-tab-page/", "key": "Enter", "code": "Enter", "selector": "ntp-app", "type": "keyboard_input", "mods": [], "t": 589}
+{"url": "https://x.com/", "type": "navigation", "to": "https://x.com/", "t": 99}
+{"url": "https://x.com/home", "type": "navigation", "to": "https://x.com/home", "t": 491}
+{"url": "https://x.com/home", "x": 385, "y": 103, "button": "left", "selector": "div>div>div>div>div:nth-of-type(2)>div>div>div>div>div", "text": "", "type": "mouse_click", "mods": [], "t": 2475}
+{"url": "https://x.com/home", "key": "t", "code": "KeyT", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 1184}
+{"url": "https://x.com/home", "key": "e", "code": "KeyE", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 88}
+{"url": "https://x.com/home", "key": "s", "code": "KeyS", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 23}
+{"url": "https://x.com/home", "key": "t", "code": "KeyT", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 85}
+{"url": "https://x.com/home", "key": "i", "code": "KeyI", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 88}
+{"url": "https://x.com/home", "key": "n", "code": "KeyN", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 72}
+{"url": "https://x.com/home", "key": "g", "code": "KeyG", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 187}
+{"url": "https://x.com/home", "key": " ", "code": "Space", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 69}
+{"url": "https://x.com/home", "key": "t", "code": "KeyT", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 121}
+{"url": "https://x.com/home", "key": "h", "code": "KeyH", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 82}
+{"url": "https://x.com/home", "key": "e", "code": "KeyE", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 44}
+{"url": "https://x.com/home", "key": " ", "code": "Space", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 115}
+{"url": "https://x.com/home", "key": "p", "code": "KeyP", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 139}
+{"url": "https://x.com/home", "key": "Backspace", "code": "Backspace", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 882}
+{"url": "https://x.com/home", "key": "i", "code": "KeyI", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 176}
+{"url": "https://x.com/home", "key": "n", "code": "KeyN", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 78}
+{"url": "https://x.com/home", "key": "p", "code": "KeyP", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 125}
+{"url": "https://x.com/home", "key": "u", "code": "KeyU", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 74}
+{"url": "https://x.com/home", "key": "t", "code": "KeyT", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 104}
+{"url": "https://x.com/home", "key": " ", "code": "Space", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 82}
+{"url": "https://x.com/home", "key": "f", "code": "KeyF", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 92}
+{"url": "https://x.com/home", "key": "r", "code": "KeyR", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 55}
+{"url": "https://x.com/home", "key": "o", "code": "KeyO", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 32}
+{"url": "https://x.com/home", "key": "m", "code": "KeyM", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 104}
+{"url": "https://x.com/home", "key": " ", "code": "Space", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 351}
+{"url": "https://x.com/home", "key": "r", "code": "KeyR", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 178}
+{"url": "https://x.com/home", "key": "e", "code": "KeyE", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 104}
+{"url": "https://x.com/home", "key": "b", "code": "KeyB", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 118}
+{"url": "https://x.com/home", "key": "r", "code": "KeyR", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 142}
+{"url": "https://x.com/home", "key": "o", "code": "KeyO", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 187}
+{"url": "https://x.com/home", "key": "w", "code": "KeyW", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 190}
+{"url": "https://x.com/home", "key": "s", "code": "KeyS", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 213}
+{"url": "https://x.com/home", "key": "e", "code": "KeyE", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 107}
+{"url": "https://x.com/home", "key": ".", "code": "Period", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 149}
+{"url": "https://x.com/home", "key": "m", "code": "KeyM", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 169}
+{"url": "https://x.com/home", "key": "e", "code": "KeyE", "selector": "div[data-testid=\"tweetTextarea_0\"]", "type": "keyboard_input", "mods": [], "t": 109}
+{"url": "https://x.com/home", "x": 681, "y": 215, "button": "left", "selector": "div:nth-of-type(2)>div>div>div>button>div>span>span", "text": "Post", "type": "mouse_click", "mods": [], "t": 13384}
+{"url": "https://x.com/home", "x": 702, "y": 200, "button": "left", "selector": "div>div:nth-of-type(2)>div>div:nth-of-type(2)>div>div>button>div>div>svg", "text": null, "type": "mouse_click", "mods": [], "t": 1479}
+{"url": "https://x.com/home", "x": 667, "y": 210, "button": "left", "selector": "div:nth-of-type(3)>div>div>div>div:nth-of-type(1)>div:nth-of-type(2)>div", "text": "Delete", "type": "mouse_click", "mods": [], "t": 441}
+{"url": "https://x.com/home", "x": 517, "y": 538, "button": "left", "selector": "button[data-testid=\"confirmationSheetConfirm\"]", "text": "Delete", "type": "mouse_click", "mods": [], "t": 685}

--- a/run_custom_chrome.sh
+++ b/run_custom_chrome.sh
@@ -2,15 +2,20 @@
 
 # Load environment variables from .env
 set -a
-[ -f .env ] && source .env
+[ -f .env ] && source .env # .env might set CHROME_REMOTE_DEBUG_PORT or CHROME_CDP_URL
 set +a
 
-# Set defaults if not set in .env
-# Note: dentify your Chrome application path:
-#  default path is for MacOS.
-CHROME_PATH=${CHROME_PATH:-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}
-CHROME_USER_DATA=${CHROME_USER_DATA:-"./custom_chrome_profile"}
+# Port for Chrome to listen on for remote debugging
+# User can set CHROME_REMOTE_DEBUG_PORT in .env to override default
 CHROME_REMOTE_DEBUG_PORT=${CHROME_REMOTE_DEBUG_PORT:-9222}
+
+# Set defaults if not set in .env for other parameters
+CHROME_PATH=${CHROME_PATH:- "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"}
+CHROME_USER_DATA=${CHROME_USER_DATA:- "./custom_chrome_profile"}
+
+echo "Starting Chrome with remote debugging on port: $CHROME_REMOTE_DEBUG_PORT"
+echo "User data directory: $CHROME_USER_DATA"
+echo "Ensure your .env or environment sets CHROME_CDP_URL=http://localhost:$CHROME_REMOTE_DEBUG_PORT (or the correct host/port if different) for webui.py to connect."
 
 "$CHROME_PATH" \
   --remote-debugging-port="$CHROME_REMOTE_DEBUG_PORT" \

--- a/src/browser/custom_context.py
+++ b/src/browser/custom_context.py
@@ -1,269 +1,285 @@
-import json
-import logging
-import os
-import asyncio
-from typing import Optional, Dict, Any
-from urllib.parse import urlparse
+from __future__ import annotations
+import logging, time, asyncio
+from pathlib import Path
+from typing import Optional
 
-from browser_use.browser.browser import Browser
-from browser_use.browser.context import BrowserContext, BrowserContextConfig
-from playwright.async_api import Browser as PlaywrightBrowser
-from playwright.async_api import BrowserContext as PlaywrightBrowserContext
-from src.utils.user_input_tracker import UserInputTracker, NavigationEvent, MouseClickEvent, KeyboardEvent, InputEvent
+from browser_use.browser.browser import Browser # Import Browser for type hinting
+from browser_use.browser.context import BrowserContext, BrowserContextConfig # Import base class and its config
+from src.browser.custom_context_config import CustomBrowserContextConfig as AppCustomBrowserContextConfig # Specific config for this app
+
+from src.utils.user_input_tracker import UserInputTracker
+from src.utils.replayer import TraceReplayer, Drift, load_trace
 
 logger = logging.getLogger(__name__)
 
+class CustomBrowserContext(BrowserContext): # Inherit from BrowserContext
+    """Wrapper around a Playwright BrowserContext to add record/replay helpers."""
 
-class CustomBrowserContext(BrowserContext):
-    def __init__(
-            self,
-            browser: "Browser",
-            config: BrowserContextConfig = BrowserContextConfig(),
-            playwright_context=None
-    ):
-        super().__init__(browser=browser, config=config)
-        self.playwright_context = playwright_context
+    # ---------------- construction helpers -----------------
+
+    def __init__(self, pw_context, browser: 'Browser', config: AppCustomBrowserContextConfig = AppCustomBrowserContextConfig()): # Add browser and config
+        super().__init__(browser=browser, config=config) # Call super with browser and config
+        self._ctx = pw_context                          # Playwright BrowserContext
+        # self._pages = pw_context.pages # pages is a dynamic property
         self.input_tracker: Optional[UserInputTracker] = None
-        self.tracking_enabled = False
-        self.tracking_save_path = getattr(config, 'save_input_tracking_path', "./tmp/input_tracking")
-        self.session = None
+        # self.save_dir is now handled by base class if config is used correctly, or can be specific here
+        # For now, let specific save_dir override if base doesn't use it from config the same way.
+        self.save_dir = Path(getattr(config, 'save_input_tracking_path', "./tmp/input_tracking")) 
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+        self._dom_bridge_initialized_on_context = False # New instance flag
+
+        # Removed: asyncio.create_task(self._ensure_dom_bridge())
         
     @property
-    def pages(self):
-        if self.playwright_context:
-            return self.playwright_context.pages
-        return []
-        
-    async def start_user_input_tracking(self) -> bool:
-        """
-        Start tracking user input events through CDP.
-        
-        Returns:
-            bool: True if tracking started successfully, False otherwise
-        """
-        if self.tracking_enabled:
-            logger.warning("User input tracking is already enabled")
-            return True
-            
-        try:
-            # Create directory for saving tracks if it doesn't exist
-            if self.tracking_save_path:
-                os.makedirs(self.tracking_save_path, exist_ok=True)
-                
-            # Make sure we have a Playwright context available
-            if not self.playwright_context:
-                logger.error("Playwright context not available for input tracking")
-                return False
-                
-            # Get first page for CDP access
-            if not self.pages:
-                logger.error("No pages available in Playwright context for input tracking. Ensure a page is open or will be opened.")
-                return False
-                
-            first_page = self.pages[0]
-            # CDP session is now presumably created and managed within UserInputTracker
-            # using the context and page provided to its constructor.
-            # OLD: cdp_client = await first_page.context.new_cdp_session(first_page)
-            
-            # Initialize and start the tracker according to the new constructor signature
-            self.input_tracker = UserInputTracker(
-                context=first_page.context, 
-                page=first_page, 
-                cdp_client=first_page.context # Passing context as cdp_client as per instruction
-            )
-            # OLD: result = await self.input_tracker.start_tracking(cdp_client=cdp_client, page=first_page)
-            # NEW: start_tracking is called without arguments, UserInputTracker uses its initialized state.
-            result = await self.input_tracker.start_tracking()
-            
-            if result:
-                self.tracking_enabled = True
-                logger.info("User input tracking started")
-                return True
-            else:
-                logger.error("Failed to start user input tracking")
-                return False
-                
-        except Exception as e:
-            logger.error(f"Error starting user input tracking: {str(e)}")
-            return False
-            
-    async def stop_user_input_tracking(self, save_to_file: bool = True) -> Optional[str]:
-        """
-        Stop tracking user input events and optionally save to file.
-        
-        Args:
-            save_to_file: Whether to save tracking data to file
-            
-        Returns:
-            Optional[str]: Path to the saved tracking file if saved, None otherwise
-        """
-        if not self.tracking_enabled or not self.input_tracker:
-            logger.warning("User input tracking is not enabled or tracker not initialized")
-            return None
-            
-        try:
-            await self.input_tracker.stop_tracking()
-            self.tracking_enabled = False
-            
-            if save_to_file and self.tracking_save_path:
-                import time # Keep import local if only used here
-                timestamp = int(time.time())
-                # Ensure tracking_save_path exists (it should have been created in start_tracking)
-                os.makedirs(self.tracking_save_path, exist_ok=True)
-                filepath = os.path.join(self.tracking_save_path, f"manual_record_{timestamp}.jsonl")
-                
-                jsonl_data = self.input_tracker.export_events_to_jsonl()
-                try:
-                    with open(filepath, 'w') as f:
-                        f.write(jsonl_data)
-                    logger.info(f"Saved user input tracking to {filepath}")
-                    return filepath
-                except IOError as e:
-                    logger.error(f"Failed to write tracking data to file {filepath}: {e}")
-                    return None # Failed to save
-                    
-            logger.info("User input tracking stopped. Data not saved to file as per request or path issue.")
-            return None # Tracking stopped, but not saved or no path
-            
-        except Exception as e:
-            logger.error(f"Error stopping user input tracking: {str(e)}")
-            return None
-            
-    async def get_tracking_events_json(self) -> str:
-        """
-        Get the current tracking events as JSON string.
-        
-        Returns:
-            str: JSON representation of tracked events
-        """
-        if not self.input_tracker:
-            return json.dumps({"error": "No input tracker available"})
-            
-        return self.input_tracker.export_events_to_json()
-            
+    def playwright_context(self):
+        return self._ctx
+
     @classmethod
-    def from_existing(cls, pw_context: PlaywrightBrowserContext, browser_instance: "Browser", existing_config: Optional[BrowserContextConfig] = None):
-        obj = cls.__new__(cls)
-        obj.playwright_context = pw_context  # For CustomBrowserContext's own methods
-        obj._ctx = pw_context                # For BrowserContext compatibility (as per plan)
-        
-        obj.browser = browser_instance       # Reference to the parent CustomBrowser
-        
-        if existing_config:
-            obj.config = existing_config
-        else:
-            # Create a default config, or one tailored for reused contexts
-            from src.browser.custom_context_config import CustomBrowserContextConfig as AppCustomBrowserContextConfig # Local import
-            # Use a string literal default if MANUAL_TRACES_DIR is not available here.
-            obj.config = AppCustomBrowserContextConfig(
-                enable_input_tracking=True, # Or False, depending on whether reused contexts should track by default
-                save_input_tracking_path="./tmp/input_tracking",
-                _force_keep_context_alive=True # Explicitly keep reused contexts alive
-            ) 
+    def from_existing(cls, pw_context, browser: 'Browser', config: AppCustomBrowserContextConfig = AppCustomBrowserContextConfig()): # Add browser and config
+        # This method creates an instance, so it needs to provide what __init__ expects.
+        # The base BrowserContext does not have from_existing, so this is specific.
+        # It should call cls(pw_context, browser, config)
+        return cls(pw_context=pw_context, browser=browser, config=config)
 
-        obj.input_tracker = None             # Initialize as in __init__
-        obj.tracking_enabled = False         # Initialize to a safe default
-        obj._trace_path = None               # As per plan
-        obj.session = None                   # Initialize session attribute for reused contexts
-        
-        # Initialize tracking_save_path from the config, similar to __init__
-        obj.tracking_save_path = getattr(obj.config, 'save_input_tracking_path', "./tmp/input_tracking")
+    # ---------------- private bootstrap -------------------
 
-        logger.info(f"CustomBrowserContext created from existing Playwright context. Tracking save path: {obj.tracking_save_path}")
-        return obj
+    BINDING = "__uit_relay"
 
-    async def close(self) -> None:
-        """Override close to ensure we stop tracking before closing"""
-        if self.tracking_enabled and self.input_tracker:
-            await self.stop_user_input_tracking()
-            
-        await super().close()
+    async def _ensure_dom_bridge(self):
+        # Check instance flag first, then context attribute as a fallback/secondary check
+        if self._dom_bridge_initialized_on_context or getattr(self._ctx, "_uit_ready", False):
+            logger.debug("DOM bridge already considered installed on context %s. Skipping.", id(self._ctx))
+            return
         
-    async def replay_input_events(self, events_file_path: str, speed: float = 1.0) -> bool:
-        """
-        Replay recorded input events from a trace file using TraceReplayer.
+        from src.utils.user_input_tracker import UserInputTracker as UITracker # Alias for clarity
+        js_template_for_context = UITracker._JS_TEMPLATE 
         
-        Args:
-            events_file_path: Path to the events JSONL file
-            speed: Playback speed multiplier
-            
-        Returns:
-            bool: True if replay successful, False otherwise
-        """
-        logger.info(f"Attempting to replay trace file: {events_file_path} at speed {speed}x")
-        if not self.pages:
-            logger.error("No pages available for event replay. Cannot proceed.")
-            return False
-        
-        # --- Enhanced Page Selection and Initial Navigation ---
         try:
-            from src.utils.replayer import TraceReplayer, load_trace, Drift 
+            logger.debug(f"Attempting to expose binding '{self.BINDING}' on context {id(self._ctx)}.")
+            await self._ctx.expose_binding(self.BINDING, self._on_binding_wrapper)
+            logger.debug(f"Successfully exposed binding '{self.BINDING}' on context {id(self._ctx)}.")
             
-            trace_events = load_trace(events_file_path)
-            if not trace_events:
-                logger.error(f"No events found in trace file: {events_file_path}")
-                return False
+            # Yield to event loop to ensure binding registration completes before init script runs
+            await asyncio.sleep(0)
+            
+            logger.debug(f"Attempting to add init script to context {id(self._ctx)}.")
+            # Log the script content before injection
+            script_to_inject = js_template_for_context.format(binding=self.BINDING)
+            logger.debug(f"CUSTOM_CONTEXT: About to inject script (first 120 chars): {script_to_inject[:120]}")
+            await self._ctx.add_init_script(script_to_inject)
+            logger.debug(f"Successfully added init script to context {id(self._ctx)}.")
 
-            first_recorded_event = trace_events[0]
-            initial_url_from_trace = first_recorded_event.get("url")
-            if not initial_url_from_trace:
-                logger.error("Trace does not contain an initial URL in the first event. Cannot determine starting point.")
-                return False
-
-            target_page = None
-            # Try to find an existing page that matches the initial URL
-            for p in self.pages:
-                # Normalize URLs for comparison (scheme, host, path)
+            # Quick patch to confirm injection via evaluate
+            if self._ctx.pages: # Check if there are any pages in the context
                 try:
-                    trace_parsed = urlparse(initial_url_from_trace)
-                    page_parsed = urlparse(p.url)
-                    if trace_parsed.scheme == page_parsed.scheme and \
-                       trace_parsed.netloc == page_parsed.netloc and \
-                       trace_parsed.path.rstrip('/') == page_parsed.path.rstrip('/'):
-                        target_page = p
-                        logger.info(f"Found existing page matching initial trace URL: {p.url}. Will use this page.")
-                        await target_page.bring_to_front() # Ensure it's active
-                        break
-                except Exception as e:
-                    logger.warning(f"Error parsing or comparing URL during page selection: {p.url} vs {initial_url_from_trace} - {e}")
-            
-            if not target_page:
-                target_page = self.pages[0] # Default to the first page if no match found
-                logger.info(f"No existing page matched initial trace URL. Defaulting to page: {target_page.url}")
-
-            current_page_url_normalized = urlparse(target_page.url).path.rstrip('/')
-            initial_trace_url_normalized = urlparse(initial_url_from_trace).path.rstrip('/')
-            
-            # Navigate if the current URL of the target_page is different from the trace's initial URL
-            if target_page.url.rstrip('/') != initial_url_from_trace.rstrip('/'):
-                logger.info(f"Initial URL of trace ({initial_url_from_trace}) differs from current target page URL ({target_page.url}). Navigating...")
-                try:
-                    # Use domcontentloaded for potentially faster/more reliable navigation if page might be similar
-                    await target_page.goto(initial_url_from_trace, wait_until="domcontentloaded", timeout=20000) # Increased timeout slightly
-                    logger.info(f"Successfully navigated target page to initial URL: {initial_url_from_trace}")
-                except Exception as nav_exc:
-                    logger.error(f"Failed to navigate target page to initial URL {initial_url_from_trace} for replay: {nav_exc}")
-                    return False
+                    await self._ctx.pages[0].evaluate("console.log('[CUSTOM_CONTEXT] Test eval after add_init_script OK')")
+                    logger.info("[CUSTOM_CONTEXT] Test eval after add_init_script executed on page 0.")
+                except Exception as eval_err:
+                    logger.error(f"[CUSTOM_CONTEXT] Error during test eval on page 0: {eval_err}")
             else:
-                logger.info(f"Target page URL ({target_page.url}) already matches initial trace URL ({initial_url_from_trace}). No navigation needed.")
+                logger.warning("[CUSTOM_CONTEXT] No pages in context to run test eval after add_init_script.")
             
-            replayer = TraceReplayer(page=target_page, trace=trace_events)
-            await replayer.play(speed=speed) 
-            logger.info(f"Successfully replayed trace file: {events_file_path}")
-            return True
-        except FileNotFoundError:
-            logger.error(f"Trace file not found for replay: {events_file_path}")
+            setattr(self._ctx, "_uit_ready", True) # Mark on Playwright context
+            self._dom_bridge_initialized_on_context = True # Mark on CustomBrowserContext instance
+            logger.info("DOM bridge successfully installed on context %s", id(self._ctx))
+            
+        except Exception as e: # Catch Playwright's Error for already registered or other issues
+            if "already registered" in str(e).lower():
+                logger.warning(f"Binding '{self.BINDING}' or script already registered on context {id(self._ctx)}, but flags were not set. Marking as ready now. Error: {e}")
+                setattr(self._ctx, "_uit_ready", True) 
+                self._dom_bridge_initialized_on_context = True
+            else:
+                logger.error(f"Failed to install DOM bridge on context {id(self._ctx)}: {e}", exc_info=True)
+                # Do not set flags to true if it was a different error, so it might be retried if appropriate.
+                # Or, re-raise if this is considered a fatal error for context setup.
+                raise # Re-raise other errors for now
+
+    # ---------------- binding passthrough ------------------
+    
+    async def _on_binding_wrapper(self, source, payload):
+        page = source.get("page") 
+        if not page:
+            logger.error("Page not found in binding source. Cannot initialize or use tracker.")
+            return
+
+        if not self.input_tracker:
+            logger.info(f"Lazy-initializing UserInputTracker for page: {page.url} (context: {id(self._ctx)})")
+            self.input_tracker = UserInputTracker(context=self._ctx, page=page) 
+            self.input_tracker.is_recording = True 
+            self.input_tracker.current_url = page.url 
+            
+            if self.input_tracker and self.input_tracker.context and hasattr(self.input_tracker, '_setup_page_listeners'): # Extra guard for linter
+                logger.info(f"CONTEXT_EVENT: Attaching context-level 'page' event listener in CustomBrowserContext for context {id(self._ctx)}")
+                self.input_tracker.context.on("page", 
+                    lambda p: asyncio.create_task(self._log_and_setup_page_listeners(p)))
+                
+                await self.input_tracker._setup_page_listeners(page) 
+            elif not (self.input_tracker and self.input_tracker.context):
+                logger.error("Input tracker or its context not set after initialization during listener setup.")
+            elif not hasattr(self.input_tracker, '_setup_page_listeners'):
+                 logger.error("_setup_page_listeners method not found on input_tracker instance.")
+
+        if self.input_tracker:
+            await self.input_tracker._on_dom_event(source, payload) 
+        else:
+            # This case should ideally not be reached if logic above is correct
+            logger.error("Input tracker somehow still not initialized in _on_binding_wrapper before passing event.")
+
+    # New helper method to log before calling _setup_page_listeners
+    async def _log_and_setup_page_listeners(self, page_object):
+        logger.info(f"CONTEXT_EVENT: Context 'page' event fired! Page URL: {page_object.url}, Page Object ID: {id(page_object)}. Calling _setup_page_listeners.")
+        if self.input_tracker: # Ensure input_tracker still exists
+            await self.input_tracker._setup_page_listeners(page_object)
+        else:
+            logger.error("CONTEXT_EVENT: self.input_tracker is None when _log_and_setup_page_listeners was called.")
+
+    # ---------------- recording API -----------------------
+
+    async def start_input_tracking(self): 
+        await self._ensure_dom_bridge()
+
+        current_pages = self.pages
+        page_to_use = None
+
+        if current_pages:
+            # Prefer non-devtools, non-chrome internal pages
+            content_pages = [
+                p for p in current_pages 
+                if p.url and 
+                   not p.url.startswith("devtools://") and 
+                   not p.url.startswith("chrome://") and 
+                   not p.url.startswith("about:") # Also exclude about:blank from being primary unless it's the only one after filtering
+            ]
+            if content_pages:
+                page_to_use = content_pages[0]
+                logger.info(f"Using existing content page for tracking: {page_to_use.url}")
+            else:
+                # If no "ideal" content pages, check if there are any pages at all (e.g. only about:blank or chrome://newtab)
+                non_devtools_pages = [p for p in current_pages if p.url and not p.url.startswith("devtools://")]
+                if non_devtools_pages:
+                    page_to_use = non_devtools_pages[0]
+                    logger.info(f"No ideal content pages. Using first non-devtools page: {page_to_use.url}")
+                else:
+                    logger.warning("No suitable (non-devtools) pages found. Creating a new page.")
+                    page_to_use = await self.new_page()
+                    if page_to_use: await page_to_use.goto("about:blank") # Navigate to a blank page
+        else:
+            logger.info("No pages in current context. Creating a new page.")
+            page_to_use = await self.new_page()
+            if page_to_use: await page_to_use.goto("about:blank") # Navigate to a blank page
+        
+        if not page_to_use:
+            logger.error("Could not get or create a suitable page for input tracking. Tracking will not start.")
+            return
+
+        if not self.input_tracker: # Initialize UserInputTracker if it doesn't exist
+            logger.info(f"Initializing UserInputTracker for page: {page_to_use.url}")
+            self.input_tracker = UserInputTracker(context=self._ctx, page=page_to_use)
+            # The UserInputTracker.start_tracking() will call _setup_page_listeners for this page_to_use
+            await self.input_tracker.start_tracking() 
+        elif not self.input_tracker.is_recording: # If tracker exists but not recording
+            logger.info(f"Re-activating recording on existing input tracker. Ensuring it targets page: {page_to_use.url}")
+            self.input_tracker.page = page_to_use # Explicitly update the page on the existing tracker
+            self.input_tracker.current_url = page_to_use.url
+            await self.input_tracker.start_tracking() # This will call _setup_page_listeners for the (potentially new) page
+        else: # Tracker exists and is recording
+            if self.input_tracker.page != page_to_use:
+                if page_to_use: # Explicitly check page_to_use is not None here
+                    logger.warning(f"Input tracker is active but on page {self.input_tracker.page.url if self.input_tracker.page else 'None'}. Forcing switch to {page_to_use.url}")
+                    self.input_tracker.page = page_to_use
+                    self.input_tracker.current_url = page_to_use.url
+                    await self.input_tracker.start_tracking() # Re-run to ensure listeners are on this page
+                else:
+                    # This case should ideally not be reached due to earlier checks, but as a safeguard:
+                    logger.error("Input tracker is active, but the determined page_to_use is None. Cannot switch tracker page.")
+            else: # self.input_tracker.page == page_to_use
+                if page_to_use: # page_to_use should not be None here if it matches a valid tracker page
+                    logger.info(f"Input tracking is already active and on the correct page: {page_to_use.url}")
+                else: # Should be an impossible state if self.input_tracker.page was not None
+                    logger.error("Input tracking is active, but page_to_use is None and matched self.input_tracker.page. Inconsistent state.")
+        
+        if page_to_use: # Final log should also be conditional
+            logger.info(f"User input tracking active. Target page: {page_to_use.url}")
+        # If page_to_use is None here, an error was logged and function returned earlier.
+
+    async def stop_input_tracking(self):
+        if self.input_tracker and self.input_tracker.is_recording:
+            await self.input_tracker.stop_tracking() 
+            filename = f"manual_record_{int(time.time())}.jsonl"
+            path = self.save_dir / filename
+            jsonl_data = self.input_tracker.export_events_to_jsonl()
+            if jsonl_data.strip():
+                path.write_text(jsonl_data)
+                logger.info("Saved user input tracking to %s", path)
+                return str(path)
+            else:
+                logger.info("No events recorded, skipping file save.")
+                return None
+        else:
+            logger.warning("Input tracking not active or tracker not initialized, nothing to stop/save.")
+            return None
+
+
+    # ---------------- replay API --------------------------
+
+    async def replay_input_events(self, trace_path: str, speed: float = 2.0, keep_open: bool = True):
+        current_pages = self.pages
+        page_for_replay = current_pages[0] if current_pages else await self.new_page()
+        if not page_for_replay:
+            logger.error("Cannot replay events, no page available.")
             return False
-        except Drift as d: # Catch Drift specifically to log its details
-            logger.error(f"Drift detected during replay of {events_file_path}: {str(d)}") # Ensure this line uses str(d)
-            if hasattr(d, 'event') and d.event: # Check if event attribute exists
-                 logger.error(f"   Drift occurred at event: {json.dumps(d.event)}")
+            
+        trace_data = load_trace(trace_path)
+        if not trace_data:
+            logger.error(f"Trace file {trace_path} is empty or could not be loaded.")
+            return False
+        
+        rep = TraceReplayer(page_for_replay, trace_data)
+        try:
+            await rep.play(speed=speed)
+            logger.info("Successfully replayed trace file: %s", trace_path)
+            return True
+        except Drift as d:
+            logger.error("Drift detected during replay of %s: %s", trace_path, d)
             return False
         except Exception as e:
-            import traceback # Keep local for this specific exception handler
-            logger.error(f"Error during event replay of {events_file_path}: {str(e)}\\n{traceback.format_exc()}")
+            import traceback
+            logger.error(f"Unexpected error during replay of {trace_path}: {e}\n{traceback.format_exc()}")
             return False
+        finally:
+            if not keep_open:
+                logger.info("Replay finished and keep_open is False. Closing context.")
+                await self.close() # Call own close method
 
-# Example of how config might be used for this context if passed directly
-# config = BrowserContextConfig(save_input_tracking_path="./my_traces")
-# context = CustomBrowserContext(browser_instance, config=config)
+    async def close(self):
+        logger.info(f"Closing CustomBrowserContext (Playwright context id: {id(self._ctx)}).")
+        # Check input_tracker before accessing is_recording
+        if hasattr(self, 'input_tracker') and self.input_tracker and self.input_tracker.is_recording:
+            logger.info("Input tracking is active, stopping it before closing context.")
+            await self.stop_input_tracking()
+        
+        if self._ctx and not self._ctx.is_closed():
+             await self._ctx.close()
+        logger.info("CustomBrowserContext closed.")
+
+    @property
+    def pages(self):
+        if self._ctx:
+            try:
+                return self._ctx.pages
+            except Exception: # Broad exception for now, ideally Playwright-specific error
+                # This can happen if the context or browser is closed.
+                return []
+        return []
+    
+    async def new_page(self, **kwargs):
+        if self._ctx:
+            try:
+                # Attempting to access pages is a way to check if context is usable
+                _ = self._ctx.pages 
+                return await self._ctx.new_page(**kwargs)
+            except Exception as e: # Catch error if context is closed
+                logger.error(f"Playwright context not available or closed when trying to create new page: {e}")
+                return None
+        logger.error("Playwright context (_ctx) is None, cannot create new page.")
+        return None

--- a/src/utils/user_input_functions.py
+++ b/src/utils/user_input_functions.py
@@ -23,7 +23,7 @@ def set_browser_context(ctx):
     """Called by webui after creating or re‑using a CustomBrowserContext."""
     global _browser_context
     _browser_context = ctx
-    logger.info("Browser context set in user_input_functions: %s", ctx)
+    logger.debug("Browser context set in user_input_functions: %s", ctx)
 
 def list_input_trace_files(directory_path_str: str) -> List[dict]:
     """Lists input trace files from the specified directory."""

--- a/webui.py
+++ b/webui.py
@@ -1,3 +1,4 @@
+from src.browser.custom_browser import CustomBrowser
 import pdb
 import logging
 import os
@@ -15,7 +16,7 @@ from task_templates import TASK_TEMPLATES
 
 # TODO: add logging configure
 logging.basicConfig(
-    level=logging.INFO,  # Set default level {logging.DEBUG, logging.INFO, logging.WARNING}
+    level=logging.DEBUG,  # Changed from INFO to DEBUG
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
 )
@@ -73,6 +74,17 @@ import json
 
 # New: user input tracking functions
 from src.utils import user_input_functions
+
+def context_is_closed(ctx) -> bool:
+    """
+    Heuristic: accessing ctx.pages on a disposed context raises an exception.
+    Works for both sync & async BrowserContext objects.
+    """
+    try:
+        _ = ctx.pages  # attribute exists on both sync/async contexts
+        return False
+    except Exception:
+        return True
 
 def _extract_initial_actions(history_json: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
@@ -980,125 +992,240 @@ async def run_repeat(
 
 # New: coroutine to start input tracking with context
 async def start_input_tracking_with_context():
-    global _global_browser, _global_browser_context
+    global _global_browser, _global_browser_context, _global_input_tracking_active, _last_manual_trace_path
 
-    if _global_browser is None:
-        logger.info("Global browser (CustomBrowser) not found for Record Tab, initializing...")
-        _global_browser = CustomBrowser(
-            config=BrowserConfig(
-                headless=False, 
-                disable_security=True, 
-                cdp_url=os.getenv("CHROME_CDP", "http://localhost:9222"), 
-                chrome_instance_path=os.getenv("CHROME_PATH", None),
-                extra_chromium_args=[]
-            )
-        )
-        await _global_browser.async_init()
-    # _global_browser is CustomBrowser, so it has playwright_browser and async_init
-    elif not (_global_browser.playwright_browser and _global_browser.playwright_browser.is_connected()):
-        logger.info("Global CustomBrowser found but not connected. Re-initializing for Record Tab...")
-        await _global_browser.async_init()
+    status_update = ""
+    trace_path_update = "" # Trace path is known after stopping, not starting
+    error_message = ""
+    start_button_interactive = True
+    stop_button_interactive = False
 
-    should_create_new_context = False
-    if _global_browser_context is None:
-        should_create_new_context = True
-    # _global_browser_context is CustomBrowserContext, so it has playwright_context
-    elif not _global_browser_context.playwright_context or not _global_browser_context.playwright_context.pages:
-        logger.info("Existing global browser context has no pages or seems invalid; will create a new one for recording.")
-        should_create_new_context = True 
-    elif _global_browser_context.playwright_context and _global_browser_context.playwright_context._connection.is_closed():
-            logger.info("Existing global browser context's connection is closed; will create a new one for recording.")
-            should_create_new_context = True
+    try:
+        logger.info("Attempting to start input tracking...")
 
-    if should_create_new_context:
-        logger.info("Attempting to initialize global browser context for input tracking.")
-        if _global_browser and _global_browser.config and _global_browser.config.cdp_url:
-            try:
-                logger.info(f"Reusing existing browser context via CDP: {_global_browser.config.cdp_url}")
-                _global_browser_context = await _global_browser.reuse_existing_context()
-                logger.info(f"Successfully reused existing browser context: {_global_browser_context}")
-                if _global_browser_context and _global_browser_context.playwright_context and not _global_browser_context.playwright_context.pages:
-                    logger.warning("Reused context has no pages. Opening a new blank tab in it for recording.")
-                    page = await _global_browser_context.playwright_context.new_page()
-                    await page.goto("about:blank") # Or a user-configurable start page
-                    await page.bring_to_front()
-            except Exception as e:
-                logger.error(f"Failed to reuse existing browser context: {e}. Falling back to new context strategy if possible.")
-                # Ensure _global_browser_context is None so fallback can occur if this path was the primary attempt
-                _global_browser_context = None 
-                # Re-raise or handle more gracefully depending on desired UX
-                # For now, if reuse fails, it will fall through to new context creation or fail if browser not init
-                pass # Allow to fall through to new context creation if reuse fails badly
-        
-        # If not using CDP or reuse failed and _global_browser_context is still None
-        if _global_browser_context is None:
-            logger.info("Initializing new browser context as not using CDP, or reuse failed.")
-            # Ensure _global_browser is initialized if it wasn't for some reason (should be by prior logic)
-            if not (_global_browser and _global_browser.playwright): # Check if browser is alive
-                 logger.error("Global browser not available for creating new context. Cannot proceed with recording setup.")
-                 return "Status: Error - Browser not available", gr.update(interactive=True), gr.update(interactive=False), None
-
-            _global_browser_context = await _global_browser.new_context(
-                config=AppCustomBrowserContextConfig(
-                    enable_input_tracking=True, 
-                    save_input_tracking_path=MANUAL_TRACES_DIR, # This comes from global
-                    browser_window_size=BrowserContextWindowSize(width=1280, height=1100) # TODO: Get from UI?
+        async with async_playwright() as p: # p is not directly used below with CustomBrowser based on other funcs
+            browser_needs_init = _global_browser is None
+            if not browser_needs_init:
+                # Corrected attribute: _playwright_browser -> playwright_browser
+                if _global_browser and (_global_browser.playwright_browser is None or not _global_browser.playwright_browser.is_connected()):
+                    logger.info("Global browser's Playwright browser instance is not connected or missing. Re-initializing browser.")
+                    browser_needs_init = True
+            
+            if browser_needs_init:
+                logger.info("Global browser not initialized or needs re-initialization. Initializing...")
+                # Use CHROME_CDP_URL for the full URL, CHROME_REMOTE_DEBUG_PORT is for the script
+                cdp_full_url = os.getenv("CHROME_CDP_URL")
+                logger.info(f"Retrieved CHROME_CDP_URL for recording: '{cdp_full_url}'") # ADDED LOGGING
+                if cdp_full_url:
+                    logger.info(f"Attempting to connect to existing browser via CDP URL: {cdp_full_url}")
+                
+                browser_config = BrowserConfig(
+                    headless=False, 
+                    cdp_url=cdp_full_url # Use the full CDP URL from env
                 )
-            )
-            if _global_browser_context and _global_browser_context.playwright_context:
-                logger.info("New browser context created for recording. Opening a new page in it.")
-                try:
-                    page = await _global_browser_context.playwright_context.new_page()
-                    await page.bring_to_front()
-                    await page.goto("https://www.google.com") # Default for new context
-                    logger.warning(f"Record Tab: A new browser context and page ('{page.url}') have been created, navigated to Google, and focused. Please use THIS page for recording.")
-                except Exception as e:
-                    logger.error(f"Error opening, navigating, or focusing new page for new context recording: {e}")
+                _global_browser = CustomBrowser(config=browser_config)
+                await _global_browser.async_init()
+                
+                # Ensure this check and status update are present
+                if not _global_browser or not _global_browser.playwright: 
+                    logger.error("Browser instantiation/initialization failed.")
+                    error_message = "Browser initialization failed."
+                    return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+                status_update += "Browser initialized. "
+                logger.info("Browser initialized.")
             else:
-                logger.error("Failed to create a new browser context properly for recording.")
-                return "Status: Error - No valid browser context (check logs)", gr.update(interactive=True), gr.update(interactive=False), None
-    
-    # DEBUGGING: Print ID of CustomBrowserContext class object used here for isinstance check
-    from src.browser.custom_context import CustomBrowserContext as CBC_in_WebUI # Alias for clarity
-    print(f"DEBUG_CHECK: ID of CustomBrowserContext class in webui.py: {id(CBC_in_WebUI)}")
+                logger.info("Using existing global browser.")
 
-    if _global_browser_context:
-        print(f"DEBUG_CHECK: _global_browser_context actual type: {type(_global_browser_context)}, ID of its type: {id(type(_global_browser_context))}")
-    else:
-        print("DEBUG_CHECK: _global_browser_context is None before isinstance check.")
-    
-    # The isinstance check below should now reliably pass if _global_browser_context is not None
-    # because it's always created as CustomBrowserContext, and webui.py imports CustomBrowserContext correctly.
-    if not isinstance(_global_browser_context, CBC_in_WebUI): # Use aliased import for the check
-        logger.error(f"Failed to obtain a valid CustomBrowserContext. Cannot start input tracking. _global_browser_context is of type: {type(_global_browser_context)}")
-        return "Status: Error - No valid browser context (check logs)", gr.update(interactive=True), gr.update(interactive=False), None
-    
-    if _global_browser_context:
-        print(f"DEBUG: _global_browser_context actual type: {type(_global_browser_context)}, module: {type(_global_browser_context).__module__}, id: {id(type(_global_browser_context))}")
-    else:
-        print("DEBUG: _global_browser_context is None before isinstance check.")
-    
-    if isinstance(_global_browser_context, CustomBrowserContext):
-        logger.info("Proceeding with input tracking as _global_browser_context is a CustomBrowserContext.")
-        user_input_functions.set_browser_context(_global_browser_context)
-        if not _global_browser_context.pages:
-            logger.error("The CustomBrowserContext has no pages. Cannot start tracking. Please ensure a page is open in the target context.")
-            return "Status: Error - Context has no pages", gr.update(interactive=True), gr.update(interactive=False), None
-        else:
-            success = await _global_browser_context.start_user_input_tracking()
-            if success:
-                logger.info("Successfully started user input tracking via CustomBrowserContext.")
-                return "Status: Recording... (Events will appear below)", gr.update(value="Recording...", interactive=False), gr.update(value="Stop Recording", interactive=True), None
+            if not (_global_browser and _global_browser.playwright):
+                logger.error("Playwright instance within CustomBrowser is not available after init/create.")
+                error_message = "Browser initialization failed (Playwright linkage). Cannot start tracking."
+                return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+
+            context_needs_init = _global_browser_context is None
+            if not context_needs_init: # if _global_browser_context exists
+                # Check if it's truly usable
+                if _global_browser_context.playwright_context is None or \
+                   context_is_closed(_global_browser_context.playwright_context):
+                    logger.info("Global browser context is unusable (closed or no Playwright context). Re-initializing context.")
+                    _global_browser_context = None # Force re-init by nullifying
+                    context_needs_init = True
+
+            if context_needs_init: # This means _global_browser_context is None or marked for re-init
+                logger.info("Global browser context needs initialization.")
+                
+                # Check if the _global_browser was connected via CDP
+                attempt_reuse = False
+                if _global_browser and _global_browser.config and _global_browser.config.cdp_url:
+                    logger.info(f"Browser was connected via CDP ({_global_browser.config.cdp_url}). Attempting to reuse existing context.")
+                    attempt_reuse = True
+                
+                if attempt_reuse:
+                    _global_browser_context = await _global_browser.reuse_existing_context()
+                    if _global_browser_context:
+                        logger.info(f"Successfully reused existing context: {_global_browser_context}")
+                        # Ensure the reused context has pages
+                        if not _global_browser_context.pages: # pages property calls _ctx.pages
+                             logger.warning("Reused context has no pages. Creating one.")
+                             try:
+                                 await _global_browser_context.new_page() # Calls _ctx.new_page()
+                             except Exception as e:
+                                 logger.error(f"Error creating page in reused context: {e}")
+                                 _global_browser_context = None # Mark reuse as failed
+                    else:
+                        logger.warning("Failed to reuse existing context or no suitable context found.")
+                
+                # If reuse was not attempted, or failed (so _global_browser_context is still None)
+                if not _global_browser_context: 
+                    if attempt_reuse: # Log if reuse was tried and failed
+                        logger.info("Falling back to creating a new browser context after failed reuse attempt.")
+                    else: # Log if reuse was not attempted (e.g. no CDP)
+                        logger.info("Proceeding to create a new browser context.")
+                    
+                    context_config_object = AppCustomBrowserContextConfig(
+                        # Defaults from AppCustomBrowserContextConfig will be used.
+                        # Specific settings like 'enable_input_tracking' are handled by explicit calls later.
+                    )
+                    if not _global_browser: 
+                         logger.error("Cannot create new context, _global_browser is None. This should not happen here.")
+                         error_message = "Critical error: Browser object became None before context creation."
+                         return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+                    
+                    _global_browser_context = await _global_browser.new_context(config=context_config_object)
+                    
+                    if _global_browser_context:
+                        logger.info("New browser context created.")
+                        # Ensure new context has a page (as per original logic)
+                        if not _global_browser_context.pages:
+                            logger.info("Newly created context has no pages. Creating one.")
+                            try:
+                                await _global_browser_context.new_page()
+                            except Exception as e:
+                                logger.error(f"Error creating page in new context: {e}")
+                                # This could be a critical failure for the new context
+                    else:
+                        logger.error("Failed to create a new browser context.")
+                        # Error handling for failed new context creation needed here
+                        error_message = "Failed to create new browser context."
+                        return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+
+
+                # Check if context creation/reuse was successful and the context is valid
+                if not _global_browser_context: # Covers failure of both reuse and new creation paths
+                    logger.error("Browser context is None after initialization attempts.")
+                    error_message = error_message or "Browser context could not be established."
+                    return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+                
+                # Now that _global_browser_context is confirmed to be not None, check its playwright_context
+                if not _global_browser_context.playwright_context:
+                    logger.error("Browser context was established, but its internal Playwright context is missing.")
+                    error_message = "Browser context is invalid (missing Playwright link)."
+                    return gr.update(value=error_message), gr.update(value=_last_manual_trace_path or "No trace yet"), gr.update(interactive=True), gr.update(interactive=False)
+
+                # Original check (now split into the two above for clarity and safety):
+                # if not (_global_browser_context and _global_browser_context.playwright_context):
+                #     logger.error("Failed to create or initialize browser context.")
+
+                current_pages = _global_browser_context.pages 
+                if not current_pages:
+                    logger.info("New context has no pages. Creating one.")
+                    await _global_browser_context.new_page()
+                    logger.info("New page created in new context.")
+                status_update += "Browser context initialized. "
+                logger.info("Browser context initialized.")
             else:
-                logger.error("CustomBrowserContext failed to start user input tracking (see browser logs).")
-                return "Status: Error starting tracking (check logs)", gr.update(interactive=True), gr.update(interactive=False), None
-    else:
-        # This block is effectively duplicated by the check at the beginning of the function now.
-        # However, keeping the original structure with the new return style.
-        logger.error(f"Failed to obtain a valid CustomBrowserContext. Cannot start input tracking. _global_browser_context is of type: {type(_global_browser_context)}")
-        return "Status: Error - No valid browser context (check logs)", gr.update(interactive=True), gr.update(interactive=False), None
+                logger.info("Using existing global browser context.")
+
+        if not _global_browser_context:
+            error_message = "Browser context is not available after setup."
+            logger.error(error_message)
+        elif _global_input_tracking_active:
+            status_update = "Input tracking is already active."
+            logger.warning(status_update)
+            start_button_interactive = False
+            stop_button_interactive = True
+        else:
+            if not os.path.exists(MANUAL_TRACES_DIR):
+                os.makedirs(MANUAL_TRACES_DIR, exist_ok=True)
+            
+            logger.info(f"Setting browser context for user_input_functions: {_global_browser_context}")
+            user_input_functions.set_browser_context(_global_browser_context)
+            
+            logger.info("Calling user_input_functions.start_input_tracking()...")
+            func_status_msg, _, _ = await user_input_functions.start_input_tracking()
+            logger.info(f"user_input_functions.start_input_tracking() returned: {func_status_msg}")
+
+            if "error" not in func_status_msg.lower() and "failed" not in func_status_msg.lower():
+                _global_input_tracking_active = True
+                status_update += f" Input tracking started. Status: {func_status_msg}"
+                trace_path_update = "Recording... (Path will be shown on stop)"
+                logger.info(status_update)
+                start_button_interactive = False
+                stop_button_interactive = True
+            else:
+                error_message = f"Failed to start tracking: {func_status_msg}"
+                logger.error(error_message)
+
+    except MissingAPIKeyError as e:
+        logger.error(f"Missing API Key: {e}")
+        error_message = f"Configuration Error: {e}. Please check your environment variables or config files."
+    except Exception as e:
+        logger.error(f"Error in start_input_tracking_with_context: {e}", exc_info=True)
+        error_message = f"An unexpected error occurred: {str(e)}"
     
-    # update_tracking_ui_elements() # REMOVED
+    if error_message and not status_update.endswith(error_message) and not status_update.startswith(error_message):
+        final_status = f"{status_update} Error: {error_message}" if status_update else error_message
+    elif error_message:
+        final_status = error_message
+    else:
+        final_status = status_update
+
+    if error_message:
+        start_button_interactive = True 
+        stop_button_interactive = False
+
+    return (
+        gr.update(value=final_status), # For input_track_status
+        gr.update(interactive=start_button_interactive), # For input_track_start_btn
+        gr.update(interactive=stop_button_interactive),  # For input_track_stop_btn
+        gr.update(value=trace_path_update or _last_manual_trace_path or "No trace yet") # For trace_file_path
+    )
+
+async def stop_input_tracking_with_context():
+    global _global_browser_context, _global_input_tracking_active, _last_manual_trace_path
+
+    if not _global_browser_context or not _global_input_tracking_active:
+        logger.warning("Input tracking not active or browser context not available.")
+        return (
+            "Tracking not active or context unavailable.", 
+            gr.update(interactive=True), 
+            gr.update(interactive=False), 
+            _last_manual_trace_path
+        )
+    
+    try:
+        logger.info("Attempting to stop user input tracking via CustomBrowserContext...")
+        filepath = await _global_browser_context.stop_input_tracking()
+        _global_input_tracking_active = False 
+        _last_manual_trace_path = filepath 
+        status_message = f"Input tracking stopped. Trace saved to: {filepath}" if filepath else "Input tracking stopped. No file saved."
+        logger.info(status_message)
+        return (
+            status_message, 
+            gr.update(value="▶️ Start Recording", interactive=True), 
+            gr.update(value="⏹️ Stop Recording", interactive=False), 
+            filepath
+        )
+    except Exception as e:
+        logger.error(f"Exception during stop_input_tracking_with_context: {e}", exc_info=True)
+        # Keep _global_input_tracking_active as is, or False, depending on desired recovery.
+        # For UI consistency, reflect that we tried to stop but failed.
+        return (
+            f"Error stopping input tracking: {e}", 
+            gr.update(interactive=True), # Allow trying to start again
+            gr.update(interactive=True), # Allow trying to stop again (though it failed)
+            _last_manual_trace_path
+        )
+
 
 def create_ui(theme_name="Citrus"):
     css = """
@@ -1612,7 +1739,7 @@ def create_ui(theme_name="Citrus"):
                 )
                 
                 input_track_stop_btn.click(
-                    fn=user_input_functions.stop_input_tracking,
+                    fn=stop_input_tracking_with_context,
                     inputs=[],
                     outputs=[input_track_status, input_track_start_btn, input_track_stop_btn, trace_file_path]
                 )
@@ -1663,11 +1790,29 @@ def create_ui(theme_name="Citrus"):
                 
                 def refresh_traces():
                     try:
-                        current_tracking_path = save_input_tracking_path.value
-                        logger.debug(f"--- DEBUG webui.refresh_traces: Path from save_input_tracking_path.value: '{current_tracking_path}' (type: {type(current_tracking_path)}) ---")
-                        if not isinstance(current_tracking_path, str) or not current_tracking_path:
-                            logger.error(f"--- DEBUG webui.refresh_traces: Invalid path: '{current_tracking_path}'. Using default MANAL_TRACES_DIR: '{MANUAL_TRACES_DIR}' ---")
-                            current_tracking_path = MANUAL_TRACES_DIR
+                        # Ensure save_input_tracking_path.value is correctly accessed if it's a Gradio component.
+                        # If refresh_traces is a top-level function, it might not have direct access to component.value.
+                        # Assuming save_input_tracking_path is accessible and its .value gives the current path string.
+                        # If save_input_tracking_path is a global string variable, then just use its name.
+                        # For this edit, I'm assuming 'save_input_tracking_path' is a Gradio component instance
+                        # available in the scope where 'refresh_traces' can access its '.value' attribute.
+                        # If 'save_input_tracking_path' is the global variable MANUAL_TRACES_DIR, use that.
+                        # Based on the UI code, save_input_tracking_path is a gr.Textbox.
+                        # This function is defined inside create_ui, so it should have access to UI elements.
+                        
+                        # Attempting to get the value. This might need adjustment based on actual scope.
+                        # Let's assume save_input_tracking_path is the Gradio component.
+                        # This function, when triggered by a button, might not have direct access to other components' live values
+                        # unless they are passed as inputs to the gr.Button().click() call.
+                        # The refresh_traces_btn.click is defined as:
+                        # fn=refresh_traces, inputs=[], outputs=[trace_files_list, trace_file_details_state]
+                        # So, it does NOT get save_input_tracking_path as an input.
+                        # This means it likely relies on the global MANUAL_TRACES_DIR or needs save_input_tracking_path as an input.
+                        # Let's use MANUAL_TRACES_DIR for now, as that's the default and less prone to scope issues here.
+                        current_tracking_path = MANUAL_TRACES_DIR 
+                        
+                        logger.debug(f"--- DEBUG webui.refresh_traces: Path being used: '{current_tracking_path}' ---")
+
                         files = user_input_functions.list_input_trace_files(current_tracking_path)
                         logger.debug(f"--- DEBUG webui.refresh_traces: Received files list (count: {len(files)}): {files if len(files) < 5 else str(files)[:200] + '...'} ---")
                         rows = []
@@ -1676,19 +1821,21 @@ def create_ui(theme_name="Citrus"):
                             if not isinstance(file_dict_item, dict):
                                 logger.warning(f"--- DEBUG webui.refresh_traces: Item {i} is not a dict, skipping. ---")
                                 continue
-                            name_val = file_dict_item.get("Name", "N/A")
-                            if not isinstance(name_val, str):
-                                logger.warning(f"--- DEBUG webui.refresh_traces: 'Name' field is not a string for item {i}: {name_val} (type: {type(name_val)}). Using 'Invalid Name'. ---")
+                            # Use lowercase keys to match the data from list_input_trace_files
+                            name_val = file_dict_item.get("name", "N/A") 
+                            created_val = file_dict_item.get("created", "N/A")
+                            size_val = file_dict_item.get("size", "N/A")
+                            events_val = file_dict_item.get("events", "N/A")
+                            
+                            if not isinstance(name_val, str): # Corrected indentation for this block
+                                logger.warning(f"--- DEBUG webui.refresh_traces: 'name' field is not a string for item {i}: {name_val} (type: {type(name_val)}). Using 'Invalid Name'. ---")
                                 name_val = "Invalid Name"
-                            created_val = file_dict_item.get("Created", "N/A")
-                            size_val = file_dict_item.get("Size", "N/A")
-                            events_val = file_dict_item.get("Events", "N/A")
                             rows.append([name_val, created_val, size_val, events_val])
                         logger.debug(f"--- DEBUG webui.refresh_traces: Processed rows for Dataframe (count: {len(rows)}): {rows if len(rows) < 5 else str(rows)[:200] + '...'} ---")
                         return rows, files
                     except Exception as e:
                         import traceback
-                        logger.error(f"Fatal error in refresh_traces: {str(e)}\\n{traceback.format_exc()}")
+                        logger.error(f"Fatal error in refresh_traces: {str(e)}\\\\n{traceback.format_exc()}")
                         return ([["Error: " + str(e), "", "", ""]], [])
                         
                 def delete_trace_file(trace_path):
@@ -1740,7 +1887,7 @@ def create_ui(theme_name="Citrus"):
                     elif not _global_browser_context.playwright_context or not _global_browser_context.playwright_context.pages:
                         logger.info("--- DEBUG replay_trace_wrapper: Existing context has no pages or invalid. Will create new one. ---")
                         should_create_new_context = True
-                    elif _global_browser_context.playwright_context and _global_browser_context.playwright_context._connection.is_closed():
+                    elif _global_browser_context.playwright_context and context_is_closed(_global_browser_context.playwright_context):
                         logger.info("--- DEBUG replay_trace_wrapper: Existing context connection closed. Will create new one. ---")
                         should_create_new_context = True
 
@@ -1794,11 +1941,29 @@ def create_ui(theme_name="Citrus"):
                          return "Error: Browser context is not ready for replay after setup."
 
                     logger.info(f"--- DEBUG replay_trace_wrapper: Setting browser context in user_input_functions. Context type: {type(_global_browser_context)} ---")
-                    user_input_functions.set_browser_context(_global_browser_context)
+                    user_input_functions.set_browser_context(_global_browser_context) # Call set_browser_context
                     
-                    status_message = await user_input_functions.replay_input_trace(trace_path_from_ui)
-                    logger.info(f"--- DEBUG replay_trace_wrapper: Replay status: {status_message} ---")
-                    return status_message
+                    try:
+                        # Call replay_input_trace and handle boolean result
+                        success = await user_input_functions.replay_input_trace(trace_path_from_ui, speed=1.0) 
+                        if success:
+                            status_message = "Input trace replay completed successfully."
+                        else:
+                            status_message = "Failed to replay input trace. See logs for details."
+                        logger.info(f"--- DEBUG replay_trace_wrapper: Replay status: {status_message} ---")
+                        return status_message
+                    finally:
+                        # Only close the browser if keep_browser_open is False
+                        # This logic depends on the keep_browser_open Gradio component's value
+                        # We need to access it correctly, assuming `keep_browser_open` is a Gradio component instance available in this scope
+                        # If `keep_browser_open` is the component itself, its value is `keep_browser_open.value` (if it's a global or passed param)
+                        # For now, I'm assuming `keep_browser_open_value` is a boolean passed or retrieved correctly.
+                        # This part of the logic was from a previous step, ensuring it remains consistent.
+                        # The user's latest request doesn't modify this finally block's condition directly,
+                        # but implies the browser closing is handled by `keep_open=True` passed to `replay_input_events`.
+                        # The `finally` block in `replay_trace_wrapper` in `webui.py` handles UI/global state browser closing.
+                        # The `keep_open` in `replay_input_events` in `custom_context.py` handles Playwright-level browser closing.
+                        pass # Ensure the finally block has a statement
 
                 trace_replay_btn.click(
                     fn=replay_trace_wrapper, # Changed to the wrapper function


### PR DESCRIPTION
## 1. Fix noticed bugs:
- [x] Reuse opened browser context for recording and replaying 
  - #43
  - #45 
- [x] Make `_verify_next_state` of `TraceReplay` user_aware; 
    - [x] identify the consistent URL query path and eval only them. Ignore the unique one-time query.
- [x] add MouseClick and KeyInput event emulation at Replayer.
    - [x]  add special key awareness: Backspace, Alt, Space. <- edit concatinate() at Replayer 
     <img width="660" alt="Screenshot 2025-05-20 at 8 39 53 AM" src="https://github.com/user-attachments/assets/c4bef177-ac61-4241-9888-78bbf24daa88" />
- [x] Global page context is not managed properly. #49 
- [x] Keyboard and mouse input duplication. #50 
- [x] Short logs on event listening
    ```
    INFO     [src.utils.user_input_tracker] 🖱️ MouseClick, url='chrome://new-tab-page/', button='left'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='x'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='.'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='c'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='o'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='m'
    INFO     [src.utils.user_input_tracker] ⌨️ KeyInput, url='chrome://new-tab-page/', key='Enter'
    INFO     [src.utils.user_input_tracker] 🧭 Navigation recorded https://x.com/
    INFO     [src.utils.user_input_tracker] 🧭 Navigation recorded https://x.com/home
    INFO     [src.utils.user_input_tracker] 🖱️ MouseClick, url='https://x.com/home', button='left'
    ```
- [x] shorten the event log from Replayer side.
    ```
    INFO     [src.utils.replayer] 🌐 Navigation, to='https://x.com/'
    INFO     [src.utils.replayer] NAVIGATED: https://x.com/
    INFO     [src.utils.replayer] 🌐 Navigation, to='https://x.com/home'
    INFO     [src.utils.replayer] NAVIGATED: https://x.com/home
    INFO     [src.utils.replayer] ⌨️ KeyInput, key:'Shift', url='https://x.com/home'
    INFO     [src.utils.replayer] ⌨️ KeyInput, key:')', url='https://x.com/home'
    INFO     [src.utils.replayer] 🖱️ MouseClick, button_text:"Post", url='https://x.com/home'
    ```

## 2. Test the robustness
- [x] Test a basic workflows

## 3. Shoot demo video    
- [x] shoot a video and add it to README and landing page.

## 4. New Target -> another PR
- [ ] add the Agent fall-back if If selector fails (element removed). It raises Drift early so the autonomous
agent can take over or you can regenerate the trace.